### PR TITLE
Centralize CPU flags to use Westmere for broad compatibility

### DIFF
--- a/Dockerfile.flatten
+++ b/Dockerfile.flatten
@@ -4,6 +4,7 @@
 
 # Extract configured disk images from checkpoint
 ARG CHECKPOINT_IMAGE=ghcr.io/vdsm-ci/vdsm-ci:ckpt-final
+ARG QEMU_CPU_FLAGS="-cpu Westmere,-invtsc"
 FROM ${CHECKPOINT_IMAGE} AS checkpoint
 
 # Get qcow2 conversion script and patched entry.sh from patched image
@@ -22,9 +23,10 @@ COPY --from=checkpoint /storage/*.img /storage/
 COPY --from=checkpoint /storage/dsm.* /storage/
 
 # Set loadvm argument to restore from final snapshot
-# Use -cpu max,-invtsc for snapshot compatibility in virtualized environments
+# Use configured CPU flags for broad compatibility
 # Note: 'final' snapshot always exists (created even when checkpoints disabled)
-ENV ARGUMENTS="-cpu max,-invtsc -loadvm final"
+ARG QEMU_CPU_FLAGS
+ENV ARGUMENTS="${QEMU_CPU_FLAGS} -loadvm final"
 ENV DISK_FMT=qcow2
 
 # Add labels for image management

--- a/build-image.sh
+++ b/build-image.sh
@@ -21,6 +21,7 @@ DSM_VM_IP=${DSM_VM_IP:-"20.20.20.21"}
 
 CONTAINER_NAME="vdsm-config"
 PATCHED_IMAGE="vdsm/virtual-dsm:patched"
+QEMU_CPU_FLAGS="-cpu Westmere,-invtsc"
 
 KEEP_CONTAINER=false
 IGNORE_CHECKPOINTS=false
@@ -64,7 +65,7 @@ run_vdsm_container() {
 
   docker rm "$CONTAINER_NAME" 2>/dev/null || true
 
-  local qemu_args="-cpu max,-invtsc"
+  local qemu_args="$QEMU_CPU_FLAGS"
   if [[ -n "$snapshot_name" ]]; then
     qemu_args="$qemu_args -loadvm $snapshot_name"
   fi
@@ -99,7 +100,7 @@ stop_and_commit() {
   )
 
   if [[ -n "$snapshot_name" ]]; then
-    changes+=("ENV ARGUMENTS=\"-cpu max,-invtsc -loadvm ${snapshot_name}\"")
+    changes+=("ENV ARGUMENTS=\"${QEMU_CPU_FLAGS} -loadvm ${snapshot_name}\"")
   fi
 
   local change_args=()
@@ -607,6 +608,7 @@ echo "Flattening image to reduce size..."
 # Use empty context since Dockerfile.flatten only copies from other images
 docker build \
   --build-arg CHECKPOINT_IMAGE="$SOURCE_IMAGE" \
+  --build-arg QEMU_CPU_FLAGS="$QEMU_CPU_FLAGS" \
   -t "$FULL_IMAGE_NAME" - < Dockerfile.flatten
 
 # Clean up temp image if created


### PR DESCRIPTION
- Define QEMU_CPU_FLAGS once in build-image.sh
- Pass to Dockerfile.flatten as build arg
- Use Westmere CPU type with -invtsc flag
- Provides better compatibility than 'max' across different systems