### PR TITLE
Centralize CPU flags to use Westmere for broad compatibility

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,17 @@ on:
 
 jobs:
   build:
-    name: Build Pre-configured VDSM Image
+    strategy:
+      matrix:
+        variant:
+          - name: kvm
+            flag: ""
+            image_suffix: ""
+          - name: tcg
+            flag: "--tcg"
+            image_suffix: "-tcg"
+
+    name: Build ${{ matrix.variant.name }} variant
     runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:
@@ -38,16 +48,17 @@ jobs:
         timeout_minutes: 60
         max_attempts: 2
         retry_wait_seconds: 60
-        command: ./build-image.sh --no-cache
+        command: ./build-image.sh --no-cache ${{ matrix.variant.flag }}
       env:
         REGISTRY: ghcr.io
-        DSM_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/vdsm-ci
+        DSM_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/vdsm-ci${{ matrix.variant.image_suffix }}
+        DSM_IMAGE_TAG: latest
 
     - name: Upload videos as artifacts
       if: always()
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
-        name: playwright-videos
+        name: playwright-videos-${{ matrix.variant.name }}
         path: videos/*.webm
         retention-days: 7
         if-no-files-found: ignore
@@ -57,5 +68,5 @@ jobs:
       run: |
         # Source version configuration
         source dsm-version.sh
-        docker push ghcr.io/${{ github.repository_owner }}/vdsm-ci:latest
-        docker push ghcr.io/${{ github.repository_owner }}/vdsm-ci:${DSM_VERSION}
+        docker push ghcr.io/${{ github.repository_owner }}/vdsm-ci${{ matrix.variant.image_suffix }}:latest
+        docker push ghcr.io/${{ github.repository_owner }}/vdsm-ci${{ matrix.variant.image_suffix }}:${DSM_VERSION}

--- a/BUILD.md
+++ b/BUILD.md
@@ -9,10 +9,19 @@ This directory contains a bash-based build system for creating pre-configured Vi
 ## Quick Start
 
 ```bash
+# Build KVM variant (default - fast, requires KVM)
 ./build-image.sh
+
+# Build TCG variant (portable, works everywhere including Mac)
+./build-image.sh --tcg
 ```
 
-This builds the complete image with default settings. The build takes ~13 minutes on first run, but checkpoint-based rebuilds are much faster.
+**Build times:**
+
+- KVM variant: Fast (hardware acceleration)
+- TCG variant: Slower (software emulation)
+
+Checkpoint-based rebuilds are much faster for both variants.
 
 ## Build Workflow
 
@@ -33,6 +42,37 @@ The build uses **bash orchestration** with **QEMU snapshots** for checkpointing,
 
 Each checkpoint is saved as a Docker image with QEMU snapshots embedded in `/storage/*.qcow2` files.
 
+## Image Variants
+
+### KVM vs TCG
+
+We build two variants of each image:
+
+**KVM Variant** (default):
+
+- Uses hardware virtualization (KVM acceleration)
+- Fast: Hardware-accelerated execution
+- Requires: Linux system with `/dev/kvm` access
+- Best for: CI/CD, production testing on Linux
+
+**TCG Variant** (`--tcg` flag):
+
+- Uses software emulation (QEMU TCG)
+- Portable: Works on all platforms including macOS
+- Slower: Software emulation (no hardware acceleration)
+- Best for: Development on Mac, cross-platform compatibility
+
+**Important:** Snapshots from KVM builds are incompatible with TCG and vice versa. Build with `--tcg` if you need to run on systems without KVM support.
+
+### Platform Compatibility
+
+| Platform | KVM Variant | TCG Variant |
+|----------|-------------|-------------|
+| Linux x86_64 with KVM | ✅ Fast | ✅ Slow |
+| Linux x86_64 no KVM | ❌ | ✅ Slow |
+| macOS (ARM64) | ❌ | ✅ Very Slow |
+| Windows WSL2 | ✅ Fast | ✅ Slow |
+
 ## Checkpoint System
 
 ### How Checkpoints Work
@@ -49,8 +89,15 @@ This allows instant restoration of DSM state without re-running automation.
 
 The build creates these images:
 
-- `ghcr.io/vdsm-ci/vdsm-ci:ckpt-start-ready` - DSM booted, ready for setup
-- `ghcr.io/vdsm-ci/vdsm-ci:latest` - Fully configured with NFS
+**KVM variant:**
+
+- `ghcr.io/vdsm-ci/vdsm-ci-kvm:ckpt-start-ready` - DSM booted, ready for setup
+- `ghcr.io/vdsm-ci/vdsm-ci-kvm:latest` - Fully configured with NFS
+
+**TCG variant:**
+
+- `ghcr.io/vdsm-ci/vdsm-ci-tcg:ckpt-start-ready` - DSM booted, ready for setup
+- `ghcr.io/vdsm-ci/vdsm-ci-tcg:latest` - Fully configured with NFS
 
 ### Resuming from Checkpoints
 

--- a/Dockerfile.flatten
+++ b/Dockerfile.flatten
@@ -4,6 +4,8 @@
 
 # Extract configured disk images from checkpoint
 ARG CHECKPOINT_IMAGE=ghcr.io/vdsm-ci/vdsm-ci:ckpt-final
+ARG QEMU_CPU_FLAGS="-cpu Westmere,-invtsc"
+ARG VARIANT=kvm
 FROM ${CHECKPOINT_IMAGE} AS checkpoint
 
 # Get qcow2 conversion script and patched entry.sh from patched image
@@ -22,14 +24,18 @@ COPY --from=checkpoint /storage/*.img /storage/
 COPY --from=checkpoint /storage/dsm.* /storage/
 
 # Set loadvm argument to restore from final snapshot
-# Use -cpu max,-invtsc for snapshot compatibility in virtualized environments
+# Use configured CPU flags for broad compatibility
 # Note: 'final' snapshot always exists (created even when checkpoints disabled)
-ENV ARGUMENTS="-cpu max,-invtsc -loadvm final"
+ARG QEMU_CPU_FLAGS
+ENV ARGUMENTS="${QEMU_CPU_FLAGS} -loadvm final"
 ENV DISK_FMT=qcow2
 
 # Add labels for image management
+ARG VARIANT
 LABEL org.opencontainers.image.vendor="vdsm-ci"
+LABEL org.opencontainers.image.description="VDSM CI image (${VARIANT} variant)"
 LABEL vdsm-ci.image.type="final"
+LABEL vdsm-ci.variant="${VARIANT}"
 LABEL vdsm-ci.managed="true"
 
 # Expose DSM and storage service ports

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ docker run -d \
   --name vdsm-test \
   --privileged \
   -p 5000:5000 \
-  ghcr.io/claytono/vdsm-ci:latest
+  ghcr.io/claytono/vdsm-ci-kvm:latest
 
 # Wait ~30 seconds for QEMU snapshot restore
 sleep 30
@@ -46,15 +46,42 @@ sleep 30
 
 ### Available Images
 
+We provide two variants optimized for different use cases:
+
+#### KVM Variant (Recommended for Linux)
+
+Fast, hardware-accelerated variant for Linux systems with KVM support:
+
 ```bash
-# Latest stable release
-ghcr.io/claytono/vdsm-ci:latest
+# Latest KVM variant
+ghcr.io/claytono/vdsm-ci-kvm:latest
 
-# Specific DSM version
-ghcr.io/claytono/vdsm-ci:7.2.2
+# Specific DSM version with KVM
+ghcr.io/claytono/vdsm-ci-kvm:7.2.2
+```
 
-# Development checkpoint (DSM booted but not configured)
-ghcr.io/vdsm-ci/vdsm-ci:ckpt-start-ready
+#### TCG Variant (For Mac and systems without KVM)
+
+Portable variant using software emulation - works on all platforms:
+
+```bash
+# Latest TCG variant
+ghcr.io/claytono/vdsm-ci-tcg:latest
+
+# Specific DSM version with TCG
+ghcr.io/claytono/vdsm-ci-tcg:7.2.2
+```
+
+**Note:** TCG variant is slower (software emulation) but provides cross-platform compatibility, including macOS.
+
+#### Development Checkpoints
+
+```bash
+# DSM booted but not configured (KVM)
+ghcr.io/vdsm-ci/vdsm-ci-kvm:ckpt-start-ready
+
+# DSM booted but not configured (TCG)
+ghcr.io/vdsm-ci/vdsm-ci-tcg:ckpt-start-ready
 ```
 
 ### Building from Source
@@ -62,7 +89,11 @@ ghcr.io/vdsm-ci/vdsm-ci:ckpt-start-ready
 To build your own image:
 
 ```bash
+# Build KVM variant (default)
 ./build-image.sh
+
+# Build TCG variant (for cross-platform compatibility)
+./build-image.sh --tcg
 ```
 
 See [BUILD.md](BUILD.md) for complete build documentation.

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 IMAGE_NAME="${1:-ghcr.io/vdsm-ci/vdsm-ci:latest}"
 CONTAINER_NAME="vdsm-smoke-test"
 SMOKE_TEST_PORT=5001
-TIMEOUT=60  # Increased for snapshot restoration
+TIMEOUT=60
 
 echo "Starting smoke test for $IMAGE_NAME..."
 


### PR DESCRIPTION
- Define QEMU_CPU_FLAGS once in build-image.sh
- Pass to Dockerfile.flatten as build arg
- Use Westmere CPU type with -invtsc flag
- Provides better compatibility than 'max' across different systems
