### PR TITLE
Add dual image variants for KVM and TCG acceleration

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,17 @@ on:
 
 jobs:
   build:
-    name: Build Pre-configured VDSM Image
+    strategy:
+      matrix:
+        variant:
+          - name: kvm
+            flag: "--kvm"
+            image_suffix: "-kvm"
+          - name: tcg
+            flag: "--tcg"
+            image_suffix: "-tcg"
+
+    name: Build ${{ matrix.variant.name }} variant
     runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:
@@ -38,16 +48,17 @@ jobs:
         timeout_minutes: 60
         max_attempts: 2
         retry_wait_seconds: 60
-        command: ./build-image.sh --no-cache
+        command: ./build-image.sh --no-cache ${{ matrix.variant.flag }}
       env:
         REGISTRY: ghcr.io
-        DSM_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/vdsm-ci
+        DSM_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/vdsm-ci${{ matrix.variant.image_suffix }}
+        DSM_IMAGE_TAG: latest
 
     - name: Upload videos as artifacts
       if: always()
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
-        name: playwright-videos
+        name: playwright-videos-${{ matrix.variant.name }}
         path: videos/*.webm
         retention-days: 7
         if-no-files-found: ignore
@@ -57,5 +68,5 @@ jobs:
       run: |
         # Source version configuration
         source dsm-version.sh
-        docker push ghcr.io/${{ github.repository_owner }}/vdsm-ci:latest
-        docker push ghcr.io/${{ github.repository_owner }}/vdsm-ci:${DSM_VERSION}
+        docker push ghcr.io/${{ github.repository_owner }}/vdsm-ci${{ matrix.variant.image_suffix }}:latest
+        docker push ghcr.io/${{ github.repository_owner }}/vdsm-ci${{ matrix.variant.image_suffix }}:${DSM_VERSION}

--- a/Dockerfile.flatten
+++ b/Dockerfile.flatten
@@ -5,6 +5,7 @@
 # Extract configured disk images from checkpoint
 ARG CHECKPOINT_IMAGE=ghcr.io/vdsm-ci/vdsm-ci:ckpt-final
 ARG QEMU_CPU_FLAGS="-cpu Westmere,-invtsc"
+ARG VARIANT=kvm
 FROM ${CHECKPOINT_IMAGE} AS checkpoint
 
 # Get qcow2 conversion script and patched entry.sh from patched image
@@ -30,8 +31,11 @@ ENV ARGUMENTS="${QEMU_CPU_FLAGS} -loadvm final"
 ENV DISK_FMT=qcow2
 
 # Add labels for image management
+ARG VARIANT
 LABEL org.opencontainers.image.vendor="vdsm-ci"
+LABEL org.opencontainers.image.description="VDSM CI image (${VARIANT} variant)"
 LABEL vdsm-ci.image.type="final"
+LABEL vdsm-ci.variant="${VARIANT}"
 LABEL vdsm-ci.managed="true"
 
 # Expose DSM and storage service ports

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ docker run -d \
   --name vdsm-test \
   --privileged \
   -p 5000:5000 \
-  ghcr.io/claytono/vdsm-ci:latest
+  ghcr.io/claytono/vdsm-ci-kvm:latest
 
 # Wait ~30 seconds for QEMU snapshot restore
 sleep 30
@@ -46,15 +46,42 @@ sleep 30
 
 ### Available Images
 
+We provide two variants optimized for different use cases:
+
+#### KVM Variant (Recommended for Linux)
+
+Fast, hardware-accelerated variant for Linux systems with KVM support:
+
 ```bash
-# Latest stable release
-ghcr.io/claytono/vdsm-ci:latest
+# Latest KVM variant
+ghcr.io/claytono/vdsm-ci-kvm:latest
 
-# Specific DSM version
-ghcr.io/claytono/vdsm-ci:7.2.2
+# Specific DSM version with KVM
+ghcr.io/claytono/vdsm-ci-kvm:7.2.2
+```
 
-# Development checkpoint (DSM booted but not configured)
-ghcr.io/vdsm-ci/vdsm-ci:ckpt-start-ready
+#### TCG Variant (For Mac and systems without KVM)
+
+Portable variant using software emulation - works on all platforms:
+
+```bash
+# Latest TCG variant
+ghcr.io/claytono/vdsm-ci-tcg:latest
+
+# Specific DSM version with TCG
+ghcr.io/claytono/vdsm-ci-tcg:7.2.2
+```
+
+**Note:** TCG variant is slower (software emulation) but provides cross-platform compatibility, including macOS.
+
+#### Development Checkpoints
+
+```bash
+# DSM booted but not configured (KVM)
+ghcr.io/vdsm-ci/vdsm-ci-kvm:ckpt-start-ready
+
+# DSM booted but not configured (TCG)
+ghcr.io/vdsm-ci/vdsm-ci-tcg:ckpt-start-ready
 ```
 
 ### Building from Source
@@ -62,7 +89,11 @@ ghcr.io/vdsm-ci/vdsm-ci:ckpt-start-ready
 To build your own image:
 
 ```bash
+# Build KVM variant (default)
 ./build-image.sh
+
+# Build TCG variant (for cross-platform compatibility)
+./build-image.sh --tcg
 ```
 
 See [BUILD.md](BUILD.md) for complete build documentation.

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 IMAGE_NAME="${1:-ghcr.io/vdsm-ci/vdsm-ci:latest}"
 CONTAINER_NAME="vdsm-smoke-test"
 SMOKE_TEST_PORT=5001
-TIMEOUT=60  # Increased for snapshot restoration
+TIMEOUT=60
 
 echo "Starting smoke test for $IMAGE_NAME..."
 


### PR DESCRIPTION
Build separate image variants to fix snapshot incompatibility between KVM
(hardware virtualization) and TCG (software emulation):

- KVM variant: ghcr.io/claytono/vdsm-ci-kvm (fast, Linux with /dev/kvm)
- TCG variant: ghcr.io/claytono/vdsm-ci-tcg (portable, works on Mac)

Auto-detects acceleration mode based on /dev/kvm presence or macOS platform.
Manual override available via --tcg or --kvm flags.

GitHub Actions builds both variants in parallel using matrix strategy.

Fixes kvmclock savevm Error -22 when running CI-built images on Mac.
