### PR TITLE
Bake KVM=N into TCG variant image

### DIFF
--- a/Dockerfile.flatten
+++ b/Dockerfile.flatten
@@ -12,7 +12,7 @@ FROM ${CHECKPOINT_IMAGE} AS checkpoint
 FROM vdsm/virtual-dsm:patched AS patched
 
 # Final image: original base + qcow2 support + configured disks
-FROM vdsm/virtual-dsm:7.41@sha256:3bec39b40ae702cdd6dc5ec25adc350ea47b01a722d60cc0805ab91969fb41cb
+FROM vdsm/virtual-dsm:7.41@sha256:3bec39b40ae702cdd6dc5ec25adc350ea47b01a722d60cc0805ab91969fb41cb AS base
 
 # Add qcow2 conversion support (copy pre-patched files)
 COPY --from=patched /run/convert.sh /run/convert.sh
@@ -29,6 +29,17 @@ COPY --from=checkpoint /storage/dsm.* /storage/
 ARG QEMU_CPU_FLAGS
 ENV ARGUMENTS="${QEMU_CPU_FLAGS} -loadvm final"
 ENV DISK_FMT=qcow2
+
+# KVM variant (default)
+FROM base AS variant-kvm
+
+# TCG variant with KVM disabled
+FROM base AS variant-tcg
+ENV KVM=N
+
+# Select final variant based on build arg
+ARG VARIANT=kvm
+FROM variant-${VARIANT} AS final
 
 # Add labels for image management
 ARG VARIANT

--- a/build-image.sh
+++ b/build-image.sh
@@ -71,6 +71,8 @@ run_vdsm_container() {
     qemu_args="$qemu_args -loadvm $snapshot_name"
   fi
 
+  # For TCG builds, we need KVM=N during checkpoint creation
+  # Otherwise snapshots will contain kvmclock state incompatible with TCG
   local kvm_args=()
   if [[ "$ACCEL_MODE" == "tcg" ]]; then
     kvm_args+=(-e KVM=N)


### PR DESCRIPTION
Use multi-stage Dockerfile to conditionally set ENV KVM=N only for TCG
variant. This eliminates the need to pass -e KVM=N at runtime.

- Dockerfile.flatten: Add variant-specific stages (variant-kvm, variant-tcg)
- TCG variant sets ENV KVM=N
- KVM variant leaves KVM unset (defaults to Y in base image)
- build-image.sh: Remove runtime -e KVM=N since it's baked into image
