### PR TITLE
Fix ghcr.io registry references to use correct namespace

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -98,8 +98,6 @@ The build creates these checkpoint images (for development/debugging):
 - `ghcr.io/claytono/vdsm-ci-tcg:ckpt-start-ready` - DSM booted, ready for setup
 - `ghcr.io/claytono/vdsm-ci-tcg:latest` - Fully configured with NFS
 
-**Note:** Published images use `ghcr.io/claytono/` namespace. Local builds use `vdsm-ci/` by default.
-
 ### Resuming from Checkpoints
 
 Speed up iteration by starting from a checkpoint:
@@ -232,7 +230,7 @@ If you see "Checkpoint 'X' does not exist":
 
 ```bash
 # List available checkpoints
-docker images ghcr.io/vdsm-ci/vdsm-ci --format "{{.Tag}}" | grep ckpt-
+docker images ghcr.io/claytono/vdsm-ci --format "{{.Tag}}" | grep ckpt-
 
 # Checkpoint names don't include the "ckpt-" prefix in --from-checkpoint
 ./build-image.sh --from-checkpoint start-ready  # Correct
@@ -246,7 +244,7 @@ Check if QEMU snapshot is valid:
 ```bash
 # Start container
 docker run -d --name vdsm-test --privileged -p 5000:5000 \
-  ghcr.io/vdsm-ci/vdsm-ci:ckpt-start-ready
+  ghcr.io/claytono/vdsm-ci-kvm:ckpt-start-ready
 
 # Check logs
 docker logs vdsm-test
@@ -265,7 +263,7 @@ docker run -d \
   -p 5000:5000 \
   --cap-add NET_ADMIN \
   --name vdsm-test \
-  ghcr.io/vdsm-ci/vdsm-ci:latest
+  ghcr.io/claytono/vdsm-ci-kvm:latest
 
 # Wait ~30 seconds for QEMU snapshot restore
 sleep 30

--- a/Dockerfile.flatten
+++ b/Dockerfile.flatten
@@ -3,7 +3,7 @@
 # Note: PAT file already removed during build by build-image.sh
 
 # Extract configured disk images from checkpoint
-ARG CHECKPOINT_IMAGE=ghcr.io/vdsm-ci/vdsm-ci:ckpt-final
+ARG CHECKPOINT_IMAGE=ghcr.io/claytono/vdsm-ci:ckpt-final
 ARG QEMU_CPU_FLAGS="-cpu Westmere,-invtsc"
 ARG VARIANT=kvm
 FROM ${CHECKPOINT_IMAGE} AS checkpoint

--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ ghcr.io/claytono/vdsm-ci-tcg:7.2.2
 
 ```bash
 # DSM booted but not configured (KVM)
-ghcr.io/vdsm-ci/vdsm-ci-kvm:ckpt-start-ready
+ghcr.io/claytono/vdsm-ci-kvm:ckpt-start-ready
 
 # DSM booted but not configured (TCG)
-ghcr.io/vdsm-ci/vdsm-ci-tcg:ckpt-start-ready
+ghcr.io/claytono/vdsm-ci-tcg:ckpt-start-ready
 ```
 
 ### Building from Source

--- a/build-image.sh
+++ b/build-image.sh
@@ -10,7 +10,7 @@ source "$BASEDIR/dsm-version.sh"
 DSM_PAT_URL="https://global.synologydownload.com/download/DSM/release/${DSM_VERSION}/${DSM_BUILD}/DSM_VirtualDSM_${DSM_BUILD}.pat"
 DSM_PAT_FILE="$BASEDIR/cache/DSM_VirtualDSM_${DSM_BUILD}.pat"
 
-IMAGE_NAME=${DSM_IMAGE_NAME:-"ghcr.io/vdsm-ci/vdsm-ci"}
+IMAGE_NAME=${DSM_IMAGE_NAME:-"ghcr.io/claytono/vdsm-ci"}
 IMAGE_TAG=${DSM_IMAGE_TAG:-"latest"}
 FULL_IMAGE_NAME="$IMAGE_NAME:$IMAGE_TAG"
 

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-IMAGE_NAME="${1:-ghcr.io/vdsm-ci/vdsm-ci:latest}"
+IMAGE_NAME="${1:-ghcr.io/claytono/vdsm-ci-kvm:latest}"
 CONTAINER_NAME="vdsm-smoke-test"
 SMOKE_TEST_PORT=5001
 TIMEOUT=60


### PR DESCRIPTION
All image references now use ghcr.io/claytono/ instead of ghcr.io/vdsm-ci/.
This matches the actual repository owner and where images are published.
