### PR TITLE
Add multi-arch support for TCG variant

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,16 +12,27 @@ jobs:
   build:
     strategy:
       matrix:
-        variant:
+        include:
+          # KVM variant: only amd64 (requires x86 KVM)
           - name: kvm
             flag: "--kvm"
             image_suffix: "-kvm"
+            runner: ubuntu-latest
+            arch: amd64
+          # TCG variant: both amd64 and arm64 (software emulation)
           - name: tcg
             flag: "--tcg"
             image_suffix: "-tcg"
+            runner: ubuntu-latest
+            arch: amd64
+          - name: tcg
+            flag: "--tcg"
+            image_suffix: "-tcg"
+            runner: ubuntu-24.04-arm
+            arch: arm64
 
-    name: Build ${{ matrix.variant.name }} variant
-    runs-on: ubuntu-latest
+    name: Build ${{ matrix.name }} variant (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
     permissions:
       contents: read
@@ -48,25 +59,71 @@ jobs:
         timeout_minutes: 60
         max_attempts: 2
         retry_wait_seconds: 60
-        command: ./build-image.sh --no-cache ${{ matrix.variant.flag }}
+        command: ./build-image.sh --no-cache ${{ matrix.flag }}
       env:
         REGISTRY: ghcr.io
-        DSM_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/vdsm-ci${{ matrix.variant.image_suffix }}
+        DSM_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/vdsm-ci${{ matrix.image_suffix }}-${{ matrix.arch }}
         DSM_IMAGE_TAG: latest
 
     - name: Upload videos as artifacts
       if: always()
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
-        name: playwright-videos-${{ matrix.variant.name }}
+        name: playwright-videos-${{ matrix.name }}-${{ matrix.arch }}
         path: videos/*.webm
         retention-days: 7
         if-no-files-found: ignore
 
-    - name: Push final image
+    - name: Push architecture-specific image
       if: github.event_name != 'pull_request'
       run: |
         # Source version configuration
         source dsm-version.sh
-        docker push ghcr.io/${{ github.repository_owner }}/vdsm-ci${{ matrix.variant.image_suffix }}:latest
-        docker push ghcr.io/${{ github.repository_owner }}/vdsm-ci${{ matrix.variant.image_suffix }}:${DSM_VERSION}
+        docker push ghcr.io/${{ github.repository_owner }}/vdsm-ci${{ matrix.image_suffix }}-${{ matrix.arch }}:latest
+        docker push ghcr.io/${{ github.repository_owner }}/vdsm-ci${{ matrix.image_suffix }}-${{ matrix.arch }}:${DSM_VERSION}
+
+  create-manifests:
+    name: Create multi-arch manifests
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+
+    - name: Log in to GitHub Container Registry
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Create and push manifests
+      if: github.event_name != 'pull_request'
+      run: |
+        # Source version configuration
+        source dsm-version.sh
+
+        # KVM: amd64 only (retag from -amd64 image)
+        docker buildx imagetools create \
+          -t ghcr.io/${{ github.repository_owner }}/vdsm-ci-kvm:latest \
+          ghcr.io/${{ github.repository_owner }}/vdsm-ci-kvm-amd64:latest
+
+        docker buildx imagetools create \
+          -t ghcr.io/${{ github.repository_owner }}/vdsm-ci-kvm:${DSM_VERSION} \
+          ghcr.io/${{ github.repository_owner }}/vdsm-ci-kvm-amd64:${DSM_VERSION}
+
+        # TCG: multi-arch manifest (combine amd64 and arm64)
+        docker buildx imagetools create \
+          -t ghcr.io/${{ github.repository_owner }}/vdsm-ci-tcg:latest \
+          ghcr.io/${{ github.repository_owner }}/vdsm-ci-tcg-amd64:latest \
+          ghcr.io/${{ github.repository_owner }}/vdsm-ci-tcg-arm64:latest
+
+        docker buildx imagetools create \
+          -t ghcr.io/${{ github.repository_owner }}/vdsm-ci-tcg:${DSM_VERSION} \
+          ghcr.io/${{ github.repository_owner }}/vdsm-ci-tcg-amd64:${DSM_VERSION} \
+          ghcr.io/${{ github.repository_owner }}/vdsm-ci-tcg-arm64:${DSM_VERSION}

--- a/BUILD.md
+++ b/BUILD.md
@@ -70,7 +70,10 @@ We build two variants of each image:
 |----------|-------------|-------------|
 | Linux x86_64 with KVM | ✅ Fast | ✅ Slow |
 | Linux x86_64 no KVM | ❌ | ✅ Slow |
+| Linux ARM64 | ❌ | ✅ Slow |
 | macOS (ARM64) | ❌ | ✅ Slow |
+
+**Multi-arch support:** TCG variant images are published as multi-arch manifests supporting both amd64 and arm64. Docker automatically pulls the correct architecture for your system.
 
 ## Checkpoint System
 

--- a/README.md
+++ b/README.md
@@ -48,21 +48,23 @@ docker run -it --rm \
 
 We provide two variants optimized for different use cases:
 
-#### KVM Variant (Recommended for Linux)
+#### KVM Variant (Recommended for x86_64 Linux)
 
-Fast, hardware-accelerated variant for Linux systems with KVM support:
+Fast, hardware-accelerated variant for x86_64 Linux systems with KVM support:
 
 ```bash
-# Latest KVM variant
+# Latest KVM variant (amd64 only)
 ghcr.io/claytono/vdsm-ci-kvm:latest
 
 # Specific DSM version with KVM
 ghcr.io/claytono/vdsm-ci-kvm:7.2.2
 ```
 
+**Note:** KVM variant is amd64-only as it requires x86 hardware virtualization.
+
 #### TCG Variant (For Mac and systems without KVM)
 
-Portable variant using software emulation - works on all platforms:
+Portable multi-arch variant using software emulation - works on all platforms:
 
 ```bash
 # Latest TCG variant (uses QEMU user networking, no devices needed)
@@ -75,7 +77,7 @@ docker run -it --rm \
 ghcr.io/claytono/vdsm-ci-tcg:7.2.2
 ```
 
-**Note:** TCG variant is slower (software emulation) but provides cross-platform compatibility, including macOS. Uses QEMU user-mode networking instead of TAP devices.
+**Note:** TCG variant is slower (software emulation) but provides cross-platform compatibility, including macOS. Docker automatically pulls the correct architecture (amd64 or arm64) for your system. Uses QEMU user-mode networking instead of TAP devices.
 
 #### Development Checkpoints
 


### PR DESCRIPTION
Build TCG variant on both amd64 and arm64 runners, then combine into
multi-arch manifest. KVM variant remains amd64-only as it requires x86
hardware virtualization.

Changes:
- Build matrix: KVM on amd64, TCG on both amd64 and arm64
- Build jobs push to arch-specific image names (e.g., vdsm-ci-tcg-amd64)
- New manifest creation job combines arch images into final user-facing images
- TCG variant published as multi-arch manifest (amd64 + arm64)
- Updated documentation to clarify architecture support
