### PR TITLE
Fix image tagging for architecture-specific names

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,7 +62,7 @@ jobs:
         command: ./build-image.sh --no-cache ${{ matrix.flag }}
       env:
         REGISTRY: ghcr.io
-        DSM_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/vdsm-ci${{ matrix.image_suffix }}-${{ matrix.arch }}
+        DSM_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/vdsm-ci${{ matrix.image_suffix }}
         DSM_IMAGE_TAG: latest
 
     - name: Upload videos as artifacts
@@ -74,11 +74,20 @@ jobs:
         retention-days: 7
         if-no-files-found: ignore
 
-    - name: Push architecture-specific image
+    - name: Tag and push architecture-specific image
       if: github.event_name != 'pull_request'
       run: |
         # Source version configuration
         source dsm-version.sh
+
+        # Tag the built image with architecture-specific names
+        docker tag ghcr.io/${{ github.repository_owner }}/vdsm-ci${{ matrix.image_suffix }}:latest \
+          ghcr.io/${{ github.repository_owner }}/vdsm-ci${{ matrix.image_suffix }}-${{ matrix.arch }}:latest
+
+        docker tag ghcr.io/${{ github.repository_owner }}/vdsm-ci${{ matrix.image_suffix }}:${DSM_VERSION} \
+          ghcr.io/${{ github.repository_owner }}/vdsm-ci${{ matrix.image_suffix }}-${{ matrix.arch }}:${DSM_VERSION}
+
+        # Push architecture-specific tags
         docker push ghcr.io/${{ github.repository_owner }}/vdsm-ci${{ matrix.image_suffix }}-${{ matrix.arch }}:latest
         docker push ghcr.io/${{ github.repository_owner }}/vdsm-ci${{ matrix.image_suffix }}-${{ matrix.arch }}:${DSM_VERSION}
 


### PR DESCRIPTION
Build script creates base image name (vdsm-ci-kvm), then we tag it with
arch suffix (vdsm-ci-kvm-amd64) before pushing. This works with the
build script's auto-suffix logic.
